### PR TITLE
[ISSUE-8] FEAT 침해 데이터 조회 / 검색 (필터링) 기능 구현

### DIFF
--- a/src/main/java/project/guakamole/domain/common/dto/PageResponse.java
+++ b/src/main/java/project/guakamole/domain/common/dto/PageResponse.java
@@ -1,4 +1,4 @@
-package project.guakamole.domain.common;
+package project.guakamole.domain.common.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/project/guakamole/domain/common/dto/SearchCondDto.java
+++ b/src/main/java/project/guakamole/domain/common/dto/SearchCondDto.java
@@ -1,0 +1,17 @@
+package project.guakamole.domain.common.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SearchCondDto {
+    private Integer searchType;
+    private String keyword;
+
+    public SearchCondDto(Integer searchType, String keyword) {
+        this.searchType = searchType;
+        this.keyword = keyword;
+    }
+}

--- a/src/main/java/project/guakamole/domain/copyright/controller/CopyrightApiController.java
+++ b/src/main/java/project/guakamole/domain/copyright/controller/CopyrightApiController.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import project.guakamole.domain.common.PageResponse;
+import project.guakamole.domain.common.dto.PageResponse;
 import project.guakamole.domain.copyright.dto.request.CreateCopyrightRequest;
 import project.guakamole.domain.copyright.service.CopyrightService;
 

--- a/src/main/java/project/guakamole/domain/copyright/entity/Copyright.java
+++ b/src/main/java/project/guakamole/domain/copyright/entity/Copyright.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE copyright SET deleted_date = CURRENT_TIMESTAMP WHERE id = ?")
+@SQLDelete(sql = "UPDATE copyright SET deleted_date = CURRENT_TIMESTAMP WHERE source_id = ?")
 @Where(clause = "deleted_date is null")
 @Entity
 public class Copyright extends BaseTimeEntity {

--- a/src/main/java/project/guakamole/domain/copyright/service/CopyrightService.java
+++ b/src/main/java/project/guakamole/domain/copyright/service/CopyrightService.java
@@ -5,7 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import project.guakamole.domain.common.PageResponse;
+import project.guakamole.domain.common.dto.PageResponse;
 import project.guakamole.domain.copyright.dto.request.CreateCopyrightRequest;
 import project.guakamole.domain.copyright.dto.response.FindCopyrightResponse;
 import project.guakamole.domain.copyright.entity.Copyright;

--- a/src/main/java/project/guakamole/domain/violation/controller/ViolationApiController.java
+++ b/src/main/java/project/guakamole/domain/violation/controller/ViolationApiController.java
@@ -1,44 +1,74 @@
 package project.guakamole.domain.violation.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import project.guakamole.domain.common.dto.PageResponse;
+import project.guakamole.domain.common.dto.SearchCondDto;
+import project.guakamole.domain.violation.dto.FilterViolationDto;
 import project.guakamole.domain.violation.dto.request.CreateViolationRequest;
-import project.guakamole.domain.violation.dto.request.UpdateReactLevelRequest;
+import project.guakamole.domain.violation.dto.request.FindViolationFilterRequest;
+import project.guakamole.domain.violation.dto.request.UpdateViolationRequest;
 import project.guakamole.domain.violation.dto.response.DetailViolationResponse;
 import project.guakamole.domain.violation.dto.response.FindViolationResponse;
 import project.guakamole.domain.violation.service.ViolationService;
 
 import java.net.URI;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/violations")
 @RequiredArgsConstructor
+@Slf4j
 public class ViolationApiController {
     private final ViolationService violationService;
 
-    @PostMapping("/violations")
-    public ResponseEntity<Long> createViolation(@RequestBody CreateViolationRequest request){
+    @PostMapping
+    public ResponseEntity<Long> createViolation(
+            @RequestBody CreateViolationRequest request)
+    {
         Long validationId = violationService.createViolation(request);
 
-        URI uri = URI.create("/api/violation/" + validationId);
+        URI uri = URI.create("/api/violations/" + validationId);
         return ResponseEntity.created(uri).build();
     }
 
-    @GetMapping("/violations")
-    public ResponseEntity<List<FindViolationResponse>> findViolations(
-            @RequestParam(name = "page", defaultValue = "0") Integer page,
-            @RequestParam(name = "size", defaultValue = "6") Integer size)
+    @GetMapping
+    public ResponseEntity<PageResponse<List<FindViolationResponse>>> findViolations(
+            @PageableDefault(sort = "id", direction = Sort.Direction.DESC, size = 10, page = 0) Pageable pageable,
+            @RequestBody(required = false) FindViolationFilterRequest filter)
     {
-        Pageable pageable = PageRequest.of(page, size);
 
-        return ResponseEntity.ok(violationService.findViolations(pageable));
+        return ResponseEntity.ok(violationService.findViolations(filter, pageable));
     }
 
-    @GetMapping("/violation/{violationId}")
+    @GetMapping("/search")
+    public ResponseEntity<PageResponse<List<FindViolationResponse>>> searchViolations(
+            @PageableDefault(sort = "id", direction = Sort.Direction.DESC, size = 10, page = 0) Pageable pageable,
+            @RequestParam(value = "searchType", required = false) Integer searchType,
+            @RequestParam(value = "keyword", required = false) String keyword,
+            @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") @RequestParam(value = "startDate", required = false) LocalDateTime startDate,
+            @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") @RequestParam(value = "endDate", required = false) LocalDateTime endDate,
+            @RequestParam(value = "agreementTypes", required = false) List<Integer> agreementTypes,
+            @RequestParam(value = "reactLevels", required = false) List<Integer> reactLevels,
+            @RequestParam(value = "minAgreementAmount", required = false) Long minAgreementAmount,
+            @RequestParam(value = "maxAgreementAmount", required = false) Long maxAgreementAmount)
+    {
+        FilterViolationDto filter = new FilterViolationDto(startDate, endDate, agreementTypes, reactLevels, minAgreementAmount, maxAgreementAmount);
+        SearchCondDto searchCond = new SearchCondDto(searchType, keyword);
+
+        return ResponseEntity.ok(violationService.searchViolation(searchCond, filter, pageable));
+    }
+
+    @GetMapping("/{violationId}")
     public ResponseEntity<DetailViolationResponse> findViolation(
             @PathVariable("violationId") Long violationId
     )
@@ -46,12 +76,22 @@ public class ViolationApiController {
         return ResponseEntity.ok(violationService.findViolation(violationId));
     }
 
-    @PutMapping("/violation/{violationId}")
-    public ResponseEntity<Void> updateReactLevel(
+    @PatchMapping(value = "/{violationId}", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<Void> updateViolation(
             @PathVariable("violationId") Long violationId,
-            @RequestBody UpdateReactLevelRequest request)
+            @RequestPart UpdateViolationRequest request,
+            @RequestPart(value = "files", required = false) MultipartFile[] files)
     {
-        violationService.updateReactLevel(request, violationId);
+        log.info(String.valueOf(files.length)); //파일 잘 받아오는지 확인
+
+        violationService.updateViolationDetail(violationId, request, files);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{violationId}")
+    public ResponseEntity<Void> deleteCopyright(@PathVariable("violationId") Long violationId) {
+        violationService.deleteViolation(violationId);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/project/guakamole/domain/violation/dto/FilterViolationDto.java
+++ b/src/main/java/project/guakamole/domain/violation/dto/FilterViolationDto.java
@@ -1,0 +1,37 @@
+package project.guakamole.domain.violation.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class FilterViolationDto {
+
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+
+    private List<Integer> agreementTypes;
+    // 1: 보류, 2: 침해합의, 3: 삭제요청, 4:법적대응
+    //null -> 모두 포함
+    private List<Integer> reactLevels;
+    // 1: 저작권자 검토, 2: 침해 대응중, 3: 대응 완료
+    // null -> 모두 포함
+
+    private Long minAgreementAmount;
+    private Long maxAgreementAmount;
+    //최소금액만 입력시 최대금액 무제한
+    //최대금액만 입력시 최소금액 0
+
+    public FilterViolationDto(LocalDateTime startDate, LocalDateTime endDate, List<Integer> agreementTypes, List<Integer> reactLevels, Long minAgreementAmount, Long maxAgreementAmount) {
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.agreementTypes = agreementTypes;
+        this.reactLevels = reactLevels;
+        this.minAgreementAmount = minAgreementAmount;
+        this.maxAgreementAmount = maxAgreementAmount;
+    }
+}

--- a/src/main/java/project/guakamole/domain/violation/dto/response/DetailViolationResponse.java
+++ b/src/main/java/project/guakamole/domain/violation/dto/response/DetailViolationResponse.java
@@ -1,5 +1,6 @@
 package project.guakamole.domain.violation.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Getter;
 import project.guakamole.domain.violation.entity.Violation;
@@ -11,7 +12,9 @@ public class DetailViolationResponse {
     private final Long sourceId;
     private final Long violateId;
     private final String violatorName;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     private final LocalDateTime violateDate;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     private final LocalDateTime reportDate;
     private final Integer violateMoment;
     private final String agreementType;
@@ -46,7 +49,7 @@ public class DetailViolationResponse {
                 .agreementType(violation.getAgreementType().getValue())
                 .agreementAmount(violation.getAgreementAmount())
                 .reactLevel(violation.getReactLevel().getValue())
-                .agreementPaymentLink("www.payment.com")
+                .agreementPaymentLink(violation.getAgreementPaymentLink())
                 .contractUrl(violation.getContractUrl())
                 .build()
                 ;

--- a/src/main/java/project/guakamole/domain/violation/dto/response/FindViolationResponse.java
+++ b/src/main/java/project/guakamole/domain/violation/dto/response/FindViolationResponse.java
@@ -1,6 +1,7 @@
 package project.guakamole.domain.violation.dto.response;
 
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Getter;
 import project.guakamole.domain.violation.entity.AgreementType;
@@ -10,6 +11,8 @@ import java.time.LocalDateTime;
 
 @Getter
 public class FindViolationResponse {
+    private final Long violateId;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     private final LocalDateTime reportDate;
     private final String agreementType;
     private final Long agreementAmount;
@@ -18,7 +21,8 @@ public class FindViolationResponse {
     private final String ownerName;
 
     @Builder
-    private FindViolationResponse(
+    public FindViolationResponse(
+            Long violateId,
             LocalDateTime reportDate,
             String agreementType,
             Long agreementAmount,
@@ -26,6 +30,7 @@ public class FindViolationResponse {
             Long sourceId,
             String ownerName)
     {
+        this.violateId = violateId;
         this.reportDate = reportDate;
         this.agreementType = agreementType;
         this.agreementAmount = agreementAmount;
@@ -36,10 +41,11 @@ public class FindViolationResponse {
 
     public static FindViolationResponse of(Violation violation){
         return FindViolationResponse.builder()
+                .violateId(violation.getId())
                 .reportDate(violation.getCreatedDate())
-                .agreementType(AgreementType.HOLD.getValue()) //임시
+                .agreementType(AgreementType.HOLD.toString()) //임시
                 .agreementAmount(Long.valueOf(0)) //임시
-                .reactLevel(violation.getReactLevel().getValue())
+                .reactLevel(violation.getReactLevel().toString())
                 .sourceId(violation.getCopyright().getId())
                 .ownerName(violation.getCopyright().getOwnerName())
                 .build()

--- a/src/main/java/project/guakamole/domain/violation/entity/AgreementType.java
+++ b/src/main/java/project/guakamole/domain/violation/entity/AgreementType.java
@@ -23,4 +23,17 @@ public enum AgreementType {
             throw new IllegalArgumentException("잘못된 접근입니다.");
         }
     }
+
+    public static AgreementType get(Integer code){
+        if(code == 1)
+            return AgreementType.HOLD;
+        else if(code == 2)
+            return AgreementType.AGREEMENT;
+        else if(code == 3)
+            return AgreementType.REQUEST_DELETE;
+        else if(code == 4)
+            return AgreementType.LEGAL_RESPONSE;
+
+        throw new IllegalArgumentException("잘못된 접근입니다.");
+    }
 }

--- a/src/main/java/project/guakamole/domain/violation/entity/ViolateReactLevel.java
+++ b/src/main/java/project/guakamole/domain/violation/entity/ViolateReactLevel.java
@@ -11,7 +11,28 @@ public enum ViolateReactLevel {
 
     private final String value;
 
-    ViolateReactLevel(String value) {
+    ViolateReactLevel(String value){
         this.value = value;
+    }
+
+    public String toString(){
+        if(this.value.equals("EXAMINE")) return "저작권자 검토";
+        else if(this.value.equals("REACT")) return "침해 대응중";
+        else if(this.value.equals("COMPLETED")) return "대응 완료";
+
+        else{
+            throw new IllegalArgumentException("잘못된 접근입니다.");
+        }
+    }
+
+    public static ViolateReactLevel get(Integer code){
+        if(code == 1)
+            return ViolateReactLevel.EXAMINE;
+        else if(code == 2)
+            return ViolateReactLevel.REACT;
+        else if(code == 3)
+             return ViolateReactLevel.COMPLETED;
+
+        throw new IllegalArgumentException("잘못된 접근입니다.");
     }
 }

--- a/src/main/java/project/guakamole/domain/violation/entity/Violation.java
+++ b/src/main/java/project/guakamole/domain/violation/entity/Violation.java
@@ -1,7 +1,10 @@
 package project.guakamole.domain.violation.entity;
 
+import com.querydsl.core.util.StringUtils;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import project.guakamole.domain.copyright.entity.Copyright;
 import project.guakamole.domain.violation.dto.request.CreateViolationRequest;
 import project.guakamole.global.base.BaseTimeEntity;
@@ -12,6 +15,8 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE violation SET deleted_date = CURRENT_TIMESTAMP WHERE id = ?")
+@Where(clause = "deleted_date is null")
 @Entity
 public class Violation extends BaseTimeEntity {
 
@@ -29,7 +34,7 @@ public class Violation extends BaseTimeEntity {
     @Column(name = "violate_date", nullable = false)
     private LocalDateTime violateDate;
     @Column(name = "violate_moment", nullable = false)
-    private int violateMoment;
+    private Integer violateMoment;
 
     @Column(name = "violate_link", nullable = false)
     private String violateLink;
@@ -51,12 +56,18 @@ public class Violation extends BaseTimeEntity {
     @Column(name = "contract_url")
     private String contractUrl;
 
+    @Column(name = "deleted_date")
+    private LocalDateTime deletedDate;
+
+    @Column(name = "agreement_payment_link")
+    private String agreementPaymentLink;
+
     @Builder
     public Violation(
             Copyright copyright,
             String violatorName,
             LocalDateTime violateDate,
-            int violateMoment,
+            Integer violateMoment,
             ViolateReactLevel reactLevel,
             String violateLink,
             AgreementType agreementType,
@@ -92,12 +103,26 @@ public class Violation extends BaseTimeEntity {
         this.images.add(image);
     }
 
-    public void updateReactLevel(String reactLevel) {
-        if(reactLevel.equals("EXAMINE")) this.reactLevel = ViolateReactLevel.EXAMINE;
-        else if(reactLevel.equals("REACT")) this.reactLevel = ViolateReactLevel.REACT;
-        else if(reactLevel.equals("COMPLETED")) this.reactLevel = ViolateReactLevel.COMPLETED;
+    public void updateReactLevel(Integer code) {
+        ViolateReactLevel reactLevel = ViolateReactLevel.get(code);
+
+        if(reactLevel == ViolateReactLevel.EXAMINE)
+            this.reactLevel = ViolateReactLevel.EXAMINE;
+
+        else if(reactLevel == ViolateReactLevel.REACT)
+            this.reactLevel = ViolateReactLevel.REACT;
+
+        else if(reactLevel == ViolateReactLevel.COMPLETED)
+            this.reactLevel = ViolateReactLevel.COMPLETED;
 
         else
             return;
+    }
+
+    public void updatePaymentLink(String paymentLink) {
+        if(StringUtils.isNullOrEmpty(paymentLink))
+            return;
+
+        this.agreementPaymentLink = paymentLink;
     }
 }

--- a/src/main/java/project/guakamole/domain/violation/repository/ViolationRepository.java
+++ b/src/main/java/project/guakamole/domain/violation/repository/ViolationRepository.java
@@ -6,8 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import project.guakamole.domain.violation.entity.Violation;
 
-public interface ViolationRepository extends JpaRepository<Violation, Long> {
+public interface ViolationRepository extends JpaRepository<Violation, Long>, ViolationSearchRepository {
 
-    @Query("SELECT v FROM Violation v")
-    Page<Violation> findViolations(Pageable pageable);
+    @Query("SELECT v FROM Violation v " +
+            "JOIN FETCH v.copyright")
+    Page<Violation> findViolationWithFilter(Pageable pageable);
 }

--- a/src/main/java/project/guakamole/domain/violation/repository/ViolationSearchRepository.java
+++ b/src/main/java/project/guakamole/domain/violation/repository/ViolationSearchRepository.java
@@ -1,0 +1,16 @@
+package project.guakamole.domain.violation.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import project.guakamole.domain.violation.dto.FilterViolationDto;
+import project.guakamole.domain.violation.dto.response.FindViolationResponse;
+import project.guakamole.domain.violation.searchtype.ViolationSearchType;
+
+public interface ViolationSearchRepository {
+
+    Page<FindViolationResponse> searchViolationWithFilter(
+            ViolationSearchType searchType,
+            String keyword,
+            FilterViolationDto filter, Pageable pageable);
+
+}

--- a/src/main/java/project/guakamole/domain/violation/repository/ViolationSearchRepositoryImpl.java
+++ b/src/main/java/project/guakamole/domain/violation/repository/ViolationSearchRepositoryImpl.java
@@ -1,0 +1,172 @@
+package project.guakamole.domain.violation.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import project.guakamole.domain.violation.dto.FilterViolationDto;
+import project.guakamole.domain.violation.dto.response.FindViolationResponse;
+import project.guakamole.domain.violation.entity.AgreementType;
+import project.guakamole.domain.violation.entity.ViolateReactLevel;
+import project.guakamole.domain.violation.searchtype.ViolationSearchType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static project.guakamole.domain.copyright.entity.QCopyright.copyright;
+import static project.guakamole.domain.violation.entity.QViolation.violation;
+
+@Repository
+@RequiredArgsConstructor
+public class ViolationSearchRepositoryImpl implements ViolationSearchRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<FindViolationResponse> searchViolationWithFilter(
+            ViolationSearchType searchType,
+            String keyword,
+            FilterViolationDto filter,
+            Pageable pageable) {
+        List<FindViolationResponse> responses = queryFactory
+                .select(
+                        Projections.constructor(FindViolationResponse.class,
+                                violation.id,
+                                violation.createdDate,
+                                violation.agreementType.stringValue(),
+                                violation.agreementAmount,
+                                violation.reactLevel.stringValue(),
+                                copyright.id,
+                                copyright.ownerName
+                        )
+                )
+                .from(violation)
+                .leftJoin(violation.copyright, copyright)
+                .where(
+                        isEqualToSearchCond(searchType, keyword),
+                        containsInDate(filter.getStartDate(), filter.getEndDate()),
+                        isEqualToAgreementType(filter.getAgreementTypes()),
+                        isEqualToReactLevel(filter.getReactLevels()),
+                        containsInAgreementAmount(filter.getMinAgreementAmount(), filter.getMaxAgreementAmount())
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long count = queryFactory
+                .select(violation.id.count())
+                .from(violation)
+                .where(
+                        isEqualToSearchCond(searchType, keyword),
+                        containsInDate(filter.getStartDate(), filter.getEndDate()),
+                        isEqualToAgreementType(filter.getAgreementTypes()),
+                        isEqualToReactLevel(filter.getReactLevels()),
+                        containsInAgreementAmount(filter.getMinAgreementAmount(), filter.getMaxAgreementAmount())
+                )
+                .fetchOne();
+
+        return new PageImpl<>(responses, pageable, count);
+    }
+
+    private BooleanExpression containsInAgreementAmount(Long minAgreementAmount, Long maxAgreementAmount) {
+        if (minAgreementAmount == null && maxAgreementAmount == null)
+            return null;
+
+        if (maxAgreementAmount == null)
+            return violation.agreementAmount.goe(minAgreementAmount);
+
+        if (minAgreementAmount == null)
+            return violation.agreementAmount.loe(maxAgreementAmount);
+
+        //minAgreeAmount 보다 크거나 같고 maxAgreementAmount보다 작거나 같다
+        return violation.agreementAmount.goe(minAgreementAmount).and(
+                violation.agreementAmount.loe(maxAgreementAmount)
+        );
+    }
+
+    private BooleanExpression isEqualToReactLevel(List<Integer> reactLevels) {
+        if (reactLevels == null || reactLevels.isEmpty())
+            return null;
+
+        BooleanExpression result = null;
+
+        // 1: 저작권자 검토, 2: 침해 대응중, 3: 대응 완료
+        for (Integer code : reactLevels){
+            if (result == null) {
+                result = violation.reactLevel.eq(ViolateReactLevel.get(code));
+            } else {
+                result = result.or(violation.reactLevel.eq(ViolateReactLevel.get(code)));
+            }
+        }
+
+        return result;
+    }
+
+    private BooleanExpression isEqualToAgreementType(List<Integer> agreementTypes) {
+        if (agreementTypes == null || agreementTypes.isEmpty())
+            return null;
+
+        BooleanExpression result = null;
+
+        // 1: 보류, 2: 침해합의, 3: 삭제요청, 4:법적대응
+        for (Integer code : agreementTypes){
+            if (result == null) {
+                result = violation.agreementType.eq(AgreementType.get(code));
+            } else {
+                result = result.or(violation.agreementType.eq(AgreementType.get(code)));
+            }
+        }
+
+        return result;
+    }
+
+    private BooleanExpression containsInDate(LocalDateTime startDate, LocalDateTime endDate) {
+        if (startDate == null && endDate == null)
+            return null;
+
+        if (endDate == null)
+            return violation.violateDate.goe(startDate);
+
+        if (startDate == null)
+            return violation.violateDate.loe(endDate);
+
+        return violation.violateDate.goe(startDate).and(
+                violation.violateDate.loe(endDate)
+        );
+    }
+
+    private static BooleanExpression isEqualToSearchCond(ViolationSearchType searchType, String keyword) {
+        if (keyword == null)
+            return null;
+
+        if (searchType == null && isLong(keyword))
+            return violation.copyright.id.eq(Long.valueOf(keyword)).
+                    or(copyright.ownerName.contains(keyword));
+
+        if (searchType == null && !isLong(keyword))
+            return violation.copyright.ownerName.contains(keyword);
+
+        if (searchType == ViolationSearchType.SOURCE_ID && isLong(keyword))
+            return violation.copyright.id.eq(Long.valueOf(keyword));
+
+        if (searchType == ViolationSearchType.OWNER_NAME)
+            return violation.copyright.ownerName.contains(keyword);
+
+        throw new IllegalArgumentException("잘못된 검색 시도입니다.");
+    }
+
+    private static boolean isLong(String strValue) {
+        try {
+            Integer.parseInt(strValue);
+            return true;
+        } catch (NumberFormatException ex) {
+            return false;
+        }
+    }
+
+
+}

--- a/src/main/java/project/guakamole/domain/violation/searchtype/ViolationSearchType.java
+++ b/src/main/java/project/guakamole/domain/violation/searchtype/ViolationSearchType.java
@@ -1,0 +1,25 @@
+package project.guakamole.domain.violation.searchtype;
+
+import lombok.Getter;
+@Getter
+public enum ViolationSearchType {
+
+    SOURCE_ID("SOURCE_ID"), //1 : sourceId로 검색
+    OWNER_NAME("OWNER_NAME"); //2 : 저작권자 명으로 검색
+
+    private final String value;
+
+    ViolationSearchType(String value) {
+        this.value = value;
+    }
+
+    public static ViolationSearchType get(Integer num){
+        if(num == null)
+            return null;
+
+        else if(num == 1) return ViolationSearchType.SOURCE_ID;
+        else if(num == 2) return ViolationSearchType.OWNER_NAME;
+
+        throw new IllegalArgumentException("잘못된 접근입니다.");
+    }
+}

--- a/src/main/java/project/guakamole/domain/violation/service/ViolationService.java
+++ b/src/main/java/project/guakamole/domain/violation/service/ViolationService.java
@@ -5,16 +5,21 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import project.guakamole.domain.common.PageResponse;
+import org.springframework.web.multipart.MultipartFile;
+import project.guakamole.domain.common.dto.PageResponse;
+import project.guakamole.domain.common.dto.SearchCondDto;
 import project.guakamole.domain.copyright.entity.Copyright;
 import project.guakamole.domain.copyright.service.CopyrightService;
+import project.guakamole.domain.violation.dto.FilterViolationDto;
 import project.guakamole.domain.violation.dto.request.CreateViolationRequest;
-import project.guakamole.domain.violation.dto.request.UpdateReactLevelRequest;
+import project.guakamole.domain.violation.dto.request.FindViolationFilterRequest;
+import project.guakamole.domain.violation.dto.request.UpdateViolationRequest;
 import project.guakamole.domain.violation.dto.response.DetailViolationResponse;
 import project.guakamole.domain.violation.dto.response.FindViolationResponse;
 import project.guakamole.domain.violation.entity.Violation;
 import project.guakamole.domain.violation.entity.ViolationImage;
 import project.guakamole.domain.violation.repository.ViolationRepository;
+import project.guakamole.domain.violation.searchtype.ViolationSearchType;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -36,15 +41,40 @@ public class ViolationService {
         return violationRepository.save(violation).getId();
     }
 
+    @Transactional
+    public void deleteViolation(Long violationId) {
+        Violation violation = findById(violationId);
+
+        violationRepository.delete(violation);
+    }
+
     @Transactional(readOnly = true)
-    public PageResponse<List<FindViolationResponse>> findViolations(Pageable pageable) {
-        Page<Violation> violationPage = violationRepository.findViolations(pageable);
+    public PageResponse<List<FindViolationResponse>> findViolations(
+            FindViolationFilterRequest filter,
+            Pageable pageable)
+    {
+        Page<Violation> violationPage = violationRepository.findViolationWithFilter(pageable);
+
         List<FindViolationResponse> response = violationPage.stream()
                 .map(FindViolationResponse::of)
                 .collect(Collectors.toList());
 
         return PageResponse.of(response, violationPage);
 
+    }
+
+    public PageResponse<List<FindViolationResponse>> searchViolation(
+            SearchCondDto searchCond,
+            FilterViolationDto filter,
+            Pageable pageable)
+    {
+        Page<FindViolationResponse> violationPages = violationRepository.searchViolationWithFilter(
+                ViolationSearchType.get(searchCond.getSearchType()),
+                searchCond.getKeyword(),
+                filter,
+                pageable);
+
+        return PageResponse.of(violationPages.getContent(), violationPages);
     }
 
     @Transactional(readOnly = true)
@@ -55,9 +85,13 @@ public class ViolationService {
     }
 
     @Transactional
-    public void updateReactLevel(UpdateReactLevelRequest request, Long violateId) {
-        Violation violation = findById(violateId);
+    public void updateViolationDetail(Long violationId, UpdateViolationRequest request, MultipartFile[] files) {
+        Violation violation = findById(violationId);
+
         violation.updateReactLevel(request.getReactLevel());
+        violation.updatePaymentLink(request.getPaymentLink());
+
+        //MultipartFile 처리 로직
     }
 
     private Violation findById(Long violationId){

--- a/src/test/java/project/guakamole/domain/copyright/CopyrightObjectCreator.java
+++ b/src/test/java/project/guakamole/domain/copyright/CopyrightObjectCreator.java
@@ -7,7 +7,7 @@ public class CopyrightObjectCreator {
     private static final String copyrightName = "저작권명";
     private static final String originalLink = "저작권 링크";
 
-    public static Copyright copyright(Long id){
+    public static Copyright autoCopyright(){
         return Copyright.builder()
                 .copyrightName(copyrightName)
                 .ownerName(ownerName)

--- a/src/test/java/project/guakamole/domain/copyright/repository/CopyrightSearchRepositoryImplTest.java
+++ b/src/test/java/project/guakamole/domain/copyright/repository/CopyrightSearchRepositoryImplTest.java
@@ -1,6 +1,8 @@
 package project.guakamole.domain.copyright.repository;
 
+import jakarta.persistence.EntityManager;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -24,12 +26,23 @@ class CopyrightSearchRepositoryImplTest {
     @Autowired
     protected CopyrightRepository copyrightRepository;
 
+    @Autowired
+    protected EntityManager entityManager;
+
+    @AfterEach
+    public void teardown() {
+        this.copyrightRepository.deleteAll();
+        this.entityManager
+                .createNativeQuery("ALTER TABLE copyright ALTER COLUMN `source_id` RESTART WITH 1")
+                .executeUpdate();
+    }
+
     @Nested
     @DisplayName("조건 검색에 따른 저작권 목록 조회")
-    class FindCopyrightsBySearchCond{
+    class SearchCopyright{
         @DisplayName("저작권자 이름으로 데이터 검색")
         @Test
-        void findCopyrightsBySearchCond_searchTypeEqOwnerName() {
+        void searchCopyright_searchTypeEqOwnerName() {
             //given
 
             // cond 1
@@ -83,7 +96,7 @@ class CopyrightSearchRepositoryImplTest {
 
         @DisplayName("저작권명으로 데이터 검색")
         @Test
-        void findCopyrightsBySearchCond_searchTypeEqCopyrightName() {
+        void searchCopyright_searchTypeEqCopyrightName() {
             //given
 
             // cond 1
@@ -137,7 +150,7 @@ class CopyrightSearchRepositoryImplTest {
 
         @DisplayName("저작권 번호로 데이터 검색")
         @Test
-        void findCopyrightsBySearchCond_searchTypeEqSourceId() {
+        void searchCopyright_searchTypeEqSourceId() {
             //given
 
             // cond 1
@@ -186,7 +199,7 @@ class CopyrightSearchRepositoryImplTest {
 
         @DisplayName("검색 유형 설정 없이 데이터 검색")
         @Test
-        void findCopyrightsBySearchCond_all_search() {
+        void searchCopyright_all_search() {
             //given
 
             // cond 1
@@ -240,7 +253,7 @@ class CopyrightSearchRepositoryImplTest {
 
         @DisplayName("검색 없이 전체 조회")
         @Test
-        void findCopyrightsBySearchCond_all() {
+        void searchCopyright_all() {
             //given
 
             // cond 1

--- a/src/test/java/project/guakamole/domain/violation/ViolationObjectCreator.java
+++ b/src/test/java/project/guakamole/domain/violation/ViolationObjectCreator.java
@@ -1,0 +1,36 @@
+package project.guakamole.domain.violation;
+
+import project.guakamole.domain.copyright.entity.Copyright;
+import project.guakamole.domain.violation.entity.AgreementType;
+import project.guakamole.domain.violation.entity.ViolateReactLevel;
+import project.guakamole.domain.violation.entity.Violation;
+
+import java.time.LocalDateTime;
+
+public class ViolationObjectCreator {
+
+    public static Violation violation(
+            Copyright copyright,
+            String violatorName,
+            LocalDateTime violateDate,
+            Integer violateMoment,
+            String link,
+            ViolateReactLevel reactLevel,
+            AgreementType agreementType,
+            Long agreementAmount)
+    {
+        return Violation.builder().
+                copyright(copyright)
+                .violatorName(violatorName)
+                .violateDate(violateDate)
+                .violateMoment(violateMoment)
+                .violateLink(link)
+                .reactLevel(reactLevel) //초기 검토중
+                .agreementType(agreementType)
+                .agreementAmount(agreementAmount)
+                .build();
+    }
+
+
+
+}

--- a/src/test/java/project/guakamole/domain/violation/repository/ViolationSearchRepositoryImplTest.java
+++ b/src/test/java/project/guakamole/domain/violation/repository/ViolationSearchRepositoryImplTest.java
@@ -1,0 +1,483 @@
+package project.guakamole.domain.violation.repository;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import project.guakamole.config.DataConfig;
+import project.guakamole.domain.copyright.CopyrightObjectCreator;
+import project.guakamole.domain.copyright.entity.Copyright;
+import project.guakamole.domain.copyright.repository.CopyrightRepository;
+import project.guakamole.domain.violation.ViolationObjectCreator;
+import project.guakamole.domain.violation.dto.FilterViolationDto;
+import project.guakamole.domain.violation.dto.response.FindViolationResponse;
+import project.guakamole.domain.violation.entity.AgreementType;
+import project.guakamole.domain.violation.entity.ViolateReactLevel;
+import project.guakamole.domain.violation.entity.Violation;
+import project.guakamole.domain.violation.searchtype.ViolationSearchType;
+import project.guakamole.global.config.JpaAuditingConfig;
+
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import({DataConfig.class, JpaAuditingConfig.class})
+@DataJpaTest
+class ViolationSearchRepositoryImplTest {
+    @Autowired
+    protected ViolationRepository violationRepository;
+    @Autowired
+    protected CopyrightRepository copyrightRepository;
+
+    @Autowired
+    protected EntityManager entityManager;
+
+    @BeforeEach
+    public void beforeEach() {
+        // cond 1
+        String ownerName1 = "저작권 소유자명1";
+        String copyrightName1 = "저작권명1";
+        String originalLink1 = "저작권 링크1";
+
+        // cond 2
+        String ownerName2 = "저작권 소유자명2";
+        String copyrightName2 = "저작권명2";
+        String originalLink2 = "저작권 링크2";
+
+        // cond 1
+        Copyright savedCopyright1 = copyrightRepository.save(CopyrightObjectCreator.copyright(ownerName1, copyrightName1, originalLink1));
+
+        //cond 2
+        Copyright savedCopyright2 = copyrightRepository.save(CopyrightObjectCreator.copyright(ownerName2, copyrightName2, originalLink2));
+
+        //cond1
+        String violatorName = "침해자명";
+        LocalDateTime violateDate = LocalDateTime.of(2022, Month.DECEMBER, 25, 0, 0, 0);
+        Integer violateMoment = 30;
+        String link = "www.link.com";
+        ViolateReactLevel reactLevel = ViolateReactLevel.EXAMINE;
+        AgreementType agreementType = AgreementType.HOLD;
+        Long agreementAmount = 10L;
+
+
+        //cond2
+        String violatorName2 = "침해자명2";
+        LocalDateTime violateDate2 = LocalDateTime.of(2022, Month.DECEMBER, 25, 0, 0, 0);
+        Integer violateMoment2 = 300;
+        String link2 = "www.link.com2";
+        ViolateReactLevel reactLevel2 = ViolateReactLevel.REACT;
+        AgreementType agreementType2 = AgreementType.AGREEMENT;
+        Long agreementAmount2 = 1L;
+        Violation savedViolation1 = violationRepository.save(ViolationObjectCreator.violation(
+                savedCopyright1,
+                violatorName,
+                violateDate,
+                violateMoment,
+                link,
+                reactLevel,
+                agreementType,
+                agreementAmount
+        ));
+
+        Violation savedViolation2 = violationRepository.save(ViolationObjectCreator.violation(
+                savedCopyright2,
+                violatorName,
+                violateDate,
+                violateMoment,
+                link,
+                reactLevel,
+                agreementType,
+                agreementAmount
+        ));
+
+        Violation savedViolation3 = violationRepository.save(ViolationObjectCreator.violation(
+                savedCopyright1,
+                violatorName2,
+                violateDate2,
+                violateMoment2,
+                link2,
+                reactLevel2,
+                agreementType2,
+                agreementAmount2
+        ));
+
+    }
+
+    @AfterEach
+    public void teardown() {
+        this.violationRepository.deleteAll();
+        this.copyrightRepository.deleteAll();
+        this.entityManager
+                .createNativeQuery("ALTER TABLE copyright ALTER COLUMN `source_id` RESTART WITH 1")
+                .executeUpdate();
+        this.entityManager
+                .createNativeQuery("ALTER TABLE violation ALTER COLUMN `id` RESTART WITH 1")
+                .executeUpdate();
+    }
+
+    @Nested
+    @DisplayName("침해 데이터 검색 조회 및 필터링")
+    class SearchViolationWithFilter {
+
+        @Nested
+        @DisplayName("필터 없이 침해 데이터 조회")
+        class SearchViolationWithFilter_noFilter {
+            @Test
+            @DisplayName("필터링 없이 저작권자 이름으로 침해 데이터를 검색하면 검색 조건에 맞는 모든 데이터가 조회된다.")
+            void searchViolationWithFilter_noFilter1() {
+                //given
+                FilterViolationDto filter = new FilterViolationDto(null, null, null, null, null, null);
+                ViolationSearchType searchType = ViolationSearchType.OWNER_NAME;
+                String keyword1 = "저작권 소유자명1";
+                String keyword2 = "저작권 소유자명2";
+                Pageable pageable = PageRequest.of(0, 10);
+
+                //when
+                Page<FindViolationResponse> result1 = violationRepository.searchViolationWithFilter(searchType, keyword1, filter, pageable);
+                Page<FindViolationResponse> result2 = violationRepository.searchViolationWithFilter(searchType, keyword2, filter, pageable);
+
+                //then
+                assertThat(result1.getContent().size()).isEqualTo(2);
+                assertThat(result1.getContent().get(0).getOwnerName()).isEqualTo("저작권 소유자명1");
+                assertThat(result2.getContent().size()).isEqualTo(1);
+                assertThat(result2.getContent().get(0).getOwnerName()).isEqualTo("저작권 소유자명2");
+            }
+
+            @Test
+            @DisplayName("필터링 없이 SourceId로 침해 데이터 검색하면 검색 조건에 맞는 모든 침해 데이터가 조회된다.")
+            void searchViolationWithFilter_noFilter2() {// cond 1
+                //given
+                FilterViolationDto filter = new FilterViolationDto(null, null, null, null, null, null);
+                ViolationSearchType searchType = ViolationSearchType.SOURCE_ID;
+                String keyword1 = "1";
+                String keyword2 = "2";
+                Pageable pageable = PageRequest.of(0, 10);
+
+                //when
+                Page<FindViolationResponse> result1 = violationRepository.searchViolationWithFilter(searchType, keyword1, filter, pageable);
+                Page<FindViolationResponse> result2 = violationRepository.searchViolationWithFilter(searchType, keyword2, filter, pageable);
+
+                //then
+                assertThat(result1.getContent().size()).isEqualTo(2);
+                assertThat(result1.getContent().get(0).getOwnerName()).isEqualTo("저작권 소유자명1");
+                assertThat(result2.getContent().size()).isEqualTo(1);
+                assertThat(result2.getContent().get(0).getOwnerName()).isEqualTo("저작권 소유자명2");
+            }
+        }
+
+        @Nested
+        @DisplayName("날짜 필터링 테스트")
+        class searchViolationWithDateFilter {
+            @Test
+            @DisplayName("startDate만 지정하면 이후 데이터가 모두 조회된다.")
+            void searchViolationWithDateFilter_1() {
+                //given
+                FilterViolationDto filter = new FilterViolationDto(
+                        LocalDateTime.of(2016, Month.JANUARY, 1, 0, 0, 0),
+                        null, null, null, null, null);
+                ViolationSearchType searchType = ViolationSearchType.SOURCE_ID;
+                String keyword1 = "1";
+                Pageable pageable = PageRequest.of(0, 10);
+
+                //when
+                Page<FindViolationResponse> result1 = violationRepository.searchViolationWithFilter(searchType, keyword1, filter, pageable);
+
+                //then
+                assertThat(result1.getContent().size()).isEqualTo(2);
+            }
+
+            @Test
+            @DisplayName("startDate와 endDate가 모두 존재하면 그 사이의 값을 조회한다.")
+            void searchViolationWithDateFilter_2() {
+                //given
+                FilterViolationDto filter = new FilterViolationDto(
+                        LocalDateTime.of(2016, Month.JANUARY, 1, 0, 0, 0),
+                        LocalDateTime.of(2017, Month.JANUARY, 1, 0, 0, 0),
+                        null, null, null, null);
+                ViolationSearchType searchType = ViolationSearchType.SOURCE_ID;
+                String keyword1 = "1";
+                Pageable pageable = PageRequest.of(0, 10);
+
+                //when
+                Page<FindViolationResponse> result1 = violationRepository.searchViolationWithFilter(searchType, keyword1, filter, pageable);
+
+                //then
+                assertThat(result1.getContent().size()).isEqualTo(0);
+            }
+
+            @Test
+            @DisplayName("startDate와 endDate가 사이의 데이터가 있으면 해당 데이터는 조회된다.")
+            void searchViolationWithDateFilter_3() {
+                //given
+                FilterViolationDto filter = new FilterViolationDto(
+                        LocalDateTime.of(2016, Month.JANUARY, 1, 0, 0, 0),
+                        LocalDateTime.of(2025, Month.JANUARY, 1, 0, 0, 0),
+                        null, null, null, null);
+                ViolationSearchType searchType = ViolationSearchType.SOURCE_ID;
+                String keyword1 = "1";
+                Pageable pageable = PageRequest.of(0, 10);
+
+                //when
+                Page<FindViolationResponse> result1 = violationRepository.searchViolationWithFilter(searchType, keyword1, filter, pageable);
+
+                //then
+                assertThat(result1.getContent().size()).isEqualTo(2);
+            }
+
+            @Test
+            @DisplayName("endDate 만 지정하면 endDate 이전 데이터가 모두 조회된다.")
+            void searchViolationWithDateFilter_4() {
+                //given
+                FilterViolationDto filter = new FilterViolationDto(
+                        null,
+                        LocalDateTime.of(2025, Month.JANUARY, 1, 0, 0, 0),
+                        null, null, null, null);
+                ViolationSearchType searchType = ViolationSearchType.SOURCE_ID;
+                String keyword1 = "1";
+                Pageable pageable = PageRequest.of(0, 10);
+
+                //when
+                Page<FindViolationResponse> result1 = violationRepository.searchViolationWithFilter(searchType, keyword1, filter, pageable);
+
+                //then
+                assertThat(result1.getContent().size()).isEqualTo(2);
+            }
+        }
+
+        @Nested
+        @DisplayName("합의 유형 필터링 테스트")
+        class SearchViolationWithAgreementType {
+
+            @Test
+            @DisplayName("합의 유형이 한 개일때는 해당 합의 유형을 가진 데이터만 조회된다.")
+            void searchViolationWithAgreementType_1() {
+                //given
+                FilterViolationDto filter = new FilterViolationDto(
+                        null, null,
+                        //보류, 침해합의, 제거 요청, 법적대응
+                        List.of(1),
+                        null, null, null);
+                ViolationSearchType searchType = ViolationSearchType.SOURCE_ID;
+                String keyword1 = "1";
+                Pageable pageable = PageRequest.of(0, 10);
+
+                //when
+                Page<FindViolationResponse> result1 = violationRepository.searchViolationWithFilter(searchType, keyword1, filter, pageable);
+
+                //then
+                assertThat(result1.getContent().size()).isEqualTo(1);
+                assertThat(result1.getContent().get(0).getAgreementType()).isEqualTo(AgreementType.HOLD.getValue());
+            }
+
+            @Test
+            @DisplayName("합의 유형 필터에 해당하는 데이터가 없으면 데이터가 조회되지 않는다.")
+            void searchViolationWithAgreementType_2() {
+                //given
+                FilterViolationDto filter = new FilterViolationDto(
+                        null, null,
+                        //보류, 침해합의, 제거 요청, 법적대응
+                        List.of(4),
+                        null, null, null);
+                ViolationSearchType searchType = ViolationSearchType.SOURCE_ID;
+                String keyword1 = "1";
+                Pageable pageable = PageRequest.of(0, 10);
+
+                //when
+                Page<FindViolationResponse> result1 = violationRepository.searchViolationWithFilter(searchType, keyword1, filter, pageable);
+
+                //then
+                assertThat(result1.getContent().size()).isEqualTo(0);
+            }
+
+            @Test
+            @DisplayName("합의 유형이 여러개인 경우에는 해당하는 합의 유형을 가진 모든 데이터가 조회된다.")
+            void searchViolationWithAgreementType_3() {
+                //given
+                FilterViolationDto filter = new FilterViolationDto(
+                        null, null,
+                        //보류, 침해합의, 제거 요청, 법적대응
+                        List.of(1, 2),
+                        null, null, null);
+                ViolationSearchType searchType = ViolationSearchType.OWNER_NAME;
+                String keyword1 = "저작권 소유자명1";
+                Pageable pageable = PageRequest.of(0, 10);
+
+                //when
+                Page<FindViolationResponse> result1 = violationRepository.searchViolationWithFilter(searchType, keyword1, filter, pageable);
+
+                //then
+                assertThat(result1.getContent().size()).isEqualTo(2);
+                assertThat(result1.getContent().get(0).getAgreementType()).isEqualTo(AgreementType.HOLD.getValue());
+                assertThat(result1.getContent().get(1).getAgreementType()).isEqualTo(AgreementType.AGREEMENT.getValue());
+            }
+        }
+
+        @Nested
+        @DisplayName("대응 단계 필터 테스트")
+        class SearchViolationWithReactLevel {
+            @Test
+            @DisplayName("선택한 대응 단계가 한 개일때는 해당 합의 유형을 가진 데이터만 조회된다.")
+            void searchViolationWithReactLevel_1() {
+                //given
+                FilterViolationDto filter = new FilterViolationDto(
+                        null, null,
+                        //검토단계, 대응단계, 완료단계
+                        List.of(1),
+                        null, null, null);
+                ViolationSearchType searchType = ViolationSearchType.SOURCE_ID;
+                String keyword1 = "1";
+                Pageable pageable = PageRequest.of(0, 10);
+
+                //when
+                Page<FindViolationResponse> result1 = violationRepository.searchViolationWithFilter(searchType, keyword1, filter, pageable);
+
+                //then
+                assertThat(result1.getContent().size()).isEqualTo(1);
+                assertThat(result1.getContent().get(0).getReactLevel()).isEqualTo(ViolateReactLevel.EXAMINE.getValue());
+            }
+
+            @Test
+            @DisplayName("선택한 대응 단계가 여러 개면 선택한 합의 유형을 가진 모든 데이터가 조회된다.")
+            void searchViolationWithReactLevel_2() {
+                //given
+                FilterViolationDto filter = new FilterViolationDto(
+                        null, null,
+                        //검토단계, 대응단계, 완료단계
+                        List.of(1, 2),
+                        null, null, null);
+                ViolationSearchType searchType = ViolationSearchType.SOURCE_ID;
+                String keyword1 = "1";
+                Pageable pageable = PageRequest.of(0, 10);
+
+                //when
+                Page<FindViolationResponse> result1 = violationRepository.searchViolationWithFilter(searchType, keyword1, filter, pageable);
+
+                //then
+                assertThat(result1.getContent().size()).isEqualTo(2);
+                assertThat(result1.getContent().get(0).getReactLevel()).isEqualTo(ViolateReactLevel.EXAMINE.getValue());
+                assertThat(result1.getContent().get(1).getReactLevel()).isEqualTo(ViolateReactLevel.REACT.getValue());
+            }
+
+            @Test
+            @DisplayName("선택한 대응 단계에 해당하는 데이터가 없으면 조회되지 않는다.")
+            void searchViolationWithReactLevel_3() {
+                //given
+                FilterViolationDto filter = new FilterViolationDto(
+                        null, null,
+                        //검토단계, 대응단계, 완료단계
+                        List.of(3, 4),
+                        null, null, null);
+                ViolationSearchType searchType = ViolationSearchType.SOURCE_ID;
+                String keyword1 = "1";
+                Pageable pageable = PageRequest.of(0, 10);
+
+                //when
+                Page<FindViolationResponse> result1 = violationRepository.searchViolationWithFilter(searchType, keyword1, filter, pageable);
+
+                //then
+                assertThat(result1.getContent().size()).isEqualTo(0);
+            }
+        }
+
+        @Nested
+        @DisplayName("합의 금액 필터 테스트")
+        class searchViolationWithAgreementAmount {
+
+            @Test
+            @DisplayName("최소 금액만 기입하면 최소 금액 이상인 데이터가 조회된다.")
+            void searchViolationWithAgreementAmount_1() {
+                //given
+                FilterViolationDto filter = new FilterViolationDto(
+                        null, null, null, null,
+                        1L, null);
+                ViolationSearchType searchType = ViolationSearchType.SOURCE_ID;
+                String keyword1 = "1";
+                Pageable pageable = PageRequest.of(0, 10);
+
+                //when
+                Page<FindViolationResponse> result1 = violationRepository.searchViolationWithFilter(searchType, keyword1, filter, pageable);
+
+                //then
+                assertThat(result1.getContent().size()).isEqualTo(2);
+            }
+
+            @Test
+            @DisplayName("최소 금액 미만인 데이터는 조회되지 않는다.")
+            void searchViolationWithAgreementAmount_1_2() {
+                //given
+                FilterViolationDto filter = new FilterViolationDto(
+                        null, null, null, null,
+                        2L, null);
+                ViolationSearchType searchType = ViolationSearchType.SOURCE_ID;
+                String keyword1 = "1";
+                Pageable pageable = PageRequest.of(0, 10);
+
+                //when
+                Page<FindViolationResponse> result1 = violationRepository.searchViolationWithFilter(searchType, keyword1, filter, pageable);
+
+                //then
+                assertThat(result1.getContent().size()).isEqualTo(1);
+            }
+
+            @Test
+            @DisplayName("최대 금액만 기입하면 최대 금액 이하인 데이터가 조회된다.")
+            void searchViolationWithAgreementAmount_2() {
+                //given
+                FilterViolationDto filter = new FilterViolationDto(
+                        null, null, null, null,
+                        null, 10L);
+                ViolationSearchType searchType = ViolationSearchType.SOURCE_ID;
+                String keyword1 = "1";
+                Pageable pageable = PageRequest.of(0, 10);
+
+                //when
+                Page<FindViolationResponse> result1 = violationRepository.searchViolationWithFilter(searchType, keyword1, filter, pageable);
+
+                //then
+                assertThat(result1.getContent().size()).isEqualTo(2);
+            }
+
+            @Test
+            @DisplayName("기입한 최대 금액 초과인 데이터는 조회되지 않는다.")
+            void searchViolationWithAgreementAmount_2_2() {
+                //given
+                FilterViolationDto filter = new FilterViolationDto(
+                        null, null, null, null,
+                        null, 9L);
+                ViolationSearchType searchType = ViolationSearchType.SOURCE_ID;
+                String keyword1 = "1";
+                Pageable pageable = PageRequest.of(0, 10);
+
+                //when
+                Page<FindViolationResponse> result1 = violationRepository.searchViolationWithFilter(searchType, keyword1, filter, pageable);
+
+                //then
+                assertThat(result1.getContent().size()).isEqualTo(1);
+            }
+
+            @Test
+            @DisplayName("최소 금액과 최대 금액 둘 다 기입하면 사이에 있는 데이터가 조회된다.")
+            void searchViolationWithAgreementAmount_3() {
+                //given
+                FilterViolationDto filter = new FilterViolationDto(
+                        null, null, null, null,
+                        1L, 10L);
+                ViolationSearchType searchType = ViolationSearchType.SOURCE_ID;
+                String keyword1 = "1";
+                Pageable pageable = PageRequest.of(0, 10);
+
+                //when
+                Page<FindViolationResponse> result1 = violationRepository.searchViolationWithFilter(searchType, keyword1, filter, pageable);
+
+                //then
+                assertThat(result1.getContent().size()).isEqualTo(2);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### 상세 내용
- 침해 데이터 목록 조회 / 검색 기능 분리
- 침해 데이터 필터링은 Querydsl 사용하여 동적 쿼리 처리
- 침해 데이터 검색 및 필터링에 대한 테스트 코드 작성
